### PR TITLE
Add CodeRequirement Extraction to App Blocking Script

### DIFF
--- a/UEM-Samples/Utilities and Tools/macOS/app_and_process_details/README.md
+++ b/UEM-Samples/Utilities and Tools/macOS/app_and_process_details/README.md
@@ -30,6 +30,7 @@ CD Hash: e16e4dd06ea262216f169400e69ab163b26c7849
 Team ID: not set
 SHA-265:  9bc8af16ae3d7dfdc6b8f795e36385b8fed206205725c4506020a64156ccf0d0
 Bundle ID: com.apple.podcasts
+Code Requirement: identifier "com.apple.podcasts" and anchor apple
 ```
 ## Contributing
 Changes and improvements welcome. Please follow the VMware Contribution guide for this repository. 

--- a/UEM-Samples/Utilities and Tools/macOS/app_and_process_details/appblock.py
+++ b/UEM-Samples/Utilities and Tools/macOS/app_and_process_details/appblock.py
@@ -2,9 +2,10 @@
 #
 # Helper tool to find required data for Workspace ONE UEM App Blocking functionality for macOS
 #
-# Created by Adam Matthews - adam@adammatthews.co.uk // matthewsa@vmware.com 
+# Original Created by Adam Matthews - adam@adammatthews.co.uk // matthewsa@vmware.com
 # Date: 6th July 2021
-#
+# CodeRequirement Additions by Ciara Spencer - github.com/cspence001
+# Date: 13th September 2024
 
 import subprocess, sys, getopt, re, argparse, os
 
@@ -15,68 +16,79 @@ parser.add_argument('--list', help='List applications', action='store_true')
 args = parser.parse_args()
 
 if args.apps:
-	app = args.apps
-	cmd = ["/usr/bin/codesign","-dv","--verbose=4",app]
-	returned_value = subprocess.run(cmd, capture_output=True) # returns the exit code in unix
+    app = args.apps
+    cmd = ["/usr/bin/codesign", "-dv", "--verbose=4", app]
+    returned_value = subprocess.run(cmd, capture_output=True)  # returns the exit code in unix
 
-	out = returned_value.stderr
+    out = returned_value.stderr
 
-	cdhash = ""
-	teamid = ""
-	sha256 = ""
-	name = ""
-	bundleid = ""
-	path = ""
+    cdhash = ""
+    teamid = ""
+    sha256 = ""
+    name = ""
+    bundleid = ""
+    path = ""
+    codereq = ""
 
-	# get CDHash
-	for line in out.splitlines():	
-		result = str(line).find('CDHash',0,10)
-		if result > 0:
-			# print(line) #CDHash
-			m = re.search('(?<=\=).*', str(line, 'utf-8').rstrip())
-			cdhash = m.group(0)
-	# get TeamIdentifier
-	for line in out.splitlines():	
-		result = str(line).find('TeamIdentifier',0,20)
-		if result > 0:
-			# print(line) #TeamID
-			m = re.search('(?<=\=).*', str(line, 'utf-8').rstrip())
-			teamid = m.group(0)
+    # Get CDHash
+    for line in out.splitlines():
+        if line.startswith(b'CDHash'):
+            m = re.search(r'(?<=\=).*', line.decode('utf-8').strip())
+            if m:
+                cdhash = m.group(0)
 
-	# Get Sha-256 Hash
-	list_files = subprocess.run(["ls", f"{app}/Contents/MacOS"], capture_output=True)
-	sha_contents = str(list_files.stdout, 'utf-8').rstrip()
-	name = sha_contents
-	sha = ["/usr/bin/openssl","dgst","-sha256",f"{app}/Contents/MacOS/{sha_contents}"]
-	sha_value = subprocess.run(sha, capture_output=True) # returns the exit code in unix
-	sha_out = sha_value.stdout
-	# print(sha_contents)
-	m = re.search('(?<=\=).*', str(sha_out, 'utf-8').rstrip())
-	sha256 = m.group(0)
+    # Get TeamIdentifier
+    for line in out.splitlines():
+        if line.startswith(b'TeamIdentifier'):
+            m = re.search(r'(?<=\=).*', line.decode('utf-8').strip())
+            if m:
+                teamid = m.group(0)
 
-	bundle_plist = subprocess.run(["osascript", "-e", f"id of app \"{sha_contents}\""], capture_output=True)
-	bundleid = str(bundle_plist.stdout, 'utf-8').strip()
+    # Get CodeRequirement
+    cmd_code_req = ["/usr/bin/codesign", "--display", "-r-", app]
+    returned_code_req = subprocess.run(cmd_code_req, capture_output=True)
+    code_req_out = returned_code_req.stdout.decode('utf-8')
 
-	print(f"Name: {name}")
-	print(f"File Path: {app}/Contents/MacOS")
-	print(f"CD Hash: {cdhash}")
-	print(f"Team ID: {teamid}")
-	print(f"SHA-265: {sha256}")
-	print(f"Bundle ID: {bundleid}")
+    for line in code_req_out.splitlines():
+        if line.startswith('designated'):
+            codereq = line.replace('designated => ', '').strip()
+
+    # Get Sha-256 Hash
+    list_files = subprocess.run(["ls", f"{app}/Contents/MacOS"], capture_output=True)
+    sha_contents = str(list_files.stdout, 'utf-8').strip()
+    name = sha_contents
+    sha = ["/usr/bin/openssl", "dgst", "-sha256", f"{app}/Contents/MacOS/{sha_contents}"]
+    sha_value = subprocess.run(sha, capture_output=True)  # returns the exit code in unix
+    sha_out = sha_value.stdout
+    m = re.search(r'(?<=\=).*', sha_out.decode('utf-8').strip())
+    if m:
+        sha256 = m.group(0)
+
+    # Get Bundle ID
+    bundle_plist = subprocess.run(["osascript", "-e", f'id of app "{sha_contents}"'], capture_output=True)
+    bundleid = str(bundle_plist.stdout, 'utf-8').strip()
+
+    print(f"Name: {name}")
+    print(f"File Path: {app}/Contents/MacOS")
+    print(f"CD Hash: {cdhash}")
+    print(f"Team ID: {teamid}")
+    print(f"SHA-256: {sha256}")
+    print(f"Bundle ID: {bundleid}")
+    print(f"Code Requirement: {codereq}")
 
 if args.list:
-	list_apps = subprocess.run(["ls"], capture_output=True, cwd="/Applications/")
-	apps_list = list_apps.stdout
+    list_apps = subprocess.run(["ls"], capture_output=True, cwd="/Applications/")
+    apps_list = list_apps.stdout
 
-	list_system_apps = subprocess.run(["ls"], capture_output=True, cwd="/System/Applications/")
-	system_apps_list = list_system_apps.stdout
+    list_system_apps = subprocess.run(["ls"], capture_output=True, cwd="/System/Applications/")
+    system_apps_list = list_system_apps.stdout
 
-	list_utility_apps = subprocess.run(["ls"], capture_output=True, cwd="/System/Applications/Utilities")
-	utility_apps_list = list_utility_apps.stdout
+    list_utility_apps = subprocess.run(["ls"], capture_output=True, cwd="/System/Applications/Utilities")
+    utility_apps_list = list_utility_apps.stdout
 
-	for line in apps_list.splitlines():	
-		print(f"/Applications/{str(line,'utf-8')}")
-	for line in system_apps_list.splitlines():		
-		print(f"/System/Applications/{str(line,'utf-8')}")
-	for line in utility_apps_list.splitlines():		
-		print(f"/System/Applications/Utilities/{str(line,'utf-8')}")
+    for line in apps_list.splitlines():
+        print(f"/Applications/{line.decode('utf-8')}")
+    for line in system_apps_list.splitlines():
+        print(f"/System/Applications/{line.decode('utf-8')}")
+    for line in utility_apps_list.splitlines():
+        print(f"/System/Applications/Utilities/{line.decode('utf-8')}")


### PR DESCRIPTION
Add CodeRequirement Extraction to App Blocking Script

Description:
Adds the extraction of the CodeRequirement field from macOS applications for implementing more granular and secure application blocking policies.

Enhanced Security: By including the CodeRequirement field, administrators can verify that applications comply with custom security policies and code signing requirements, thus improving overall security posture.
Accurate Blocking Configuration: The addition of this field ensures that the Custom XML payload used for app and process blocking contains comprehensive data, allowing for more accurate and effective blocking configurations.
Improved Compliance Monitoring: Facilitates better audit and reporting by providing detailed code signing information, which can be used to ensure compliance with organizational or regulatory standards.

Documentation Update: The script’s usage documentation has been updated to reflect the addition of the CodeRequirement field in the output.