### PR TITLE
mUU revision14

### DIFF
--- a/UEM-Samples/Utilities and Tools/macOS/macOS Updater Utility/README.md
+++ b/UEM-Samples/Utilities and Tools/macOS/macOS Updater Utility/README.md
@@ -6,7 +6,7 @@
 
 
 - **Authors**: Matt Zaske, Leon Letto, and others
-- **Email**: mzaske@vmware.com
+- **Email**: mzaske@omnissa.com
 - **Date Created**: 7/22/2022
 - **Supported Platforms**:
     - Workspace ONE UEM (22.10+) with Freestyle Workflow Engine (Scripts engine required)
@@ -147,5 +147,9 @@ Here is a breakdown of the keys and their meaning:
         -  macOS Sonoma logic
 - 2023-10-17: Revision 13.1:
     - Fix for displaying deadline date on user prompt screen
-- 2023-10-17: Revision 13.2:
+- 2024-5-14: Revision 13.2:
     - Fix for users not being prompted on major upgrades
+- 2024-10-17: Revision 14:
+    - Added support for macOS Sequoia
+    - Additional fix for users not being prompted on major upgrades
+    - Enhanced logic to reset counters (deferrals or deadline timer) on mUU profile reinstallationFix for users not being prompted on major upgrades


### PR DESCRIPTION
macOS Updater Utility revision 14:
- Added support for macOS Sequoia
- Fix for users not being prompted on major upgrades
- Enhanced logic to reset counters (deferrals or deadline timer) on mUU profile reinstallation

Signed-off-by: Matt Zaske <mzaske3@gmail.com>