### PR TITLE
Adding Ansible playbooks and roles for Horizon Server Lifecycle Management API's

### DIFF
--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/README.md
@@ -1,0 +1,56 @@
+# Horizon Server Lifecycle Management
+
+Author: Guruprasad B S, Omnissa
+Last Edit: July 24,2025
+Version 1.0 
+
+<!-- Summary Start -->
+
+Horizon server lifecycle management refers to the automation and simplification of installing and upgrading Omnissa Horizon Connection Server and Enrollment Server instances using Lifecycle Management (LCM) APIs. 
+These APIs, introduced in Horizon 8 version 2406, allow administrators to automate these processes and manage the server's lifecycle more efficiently. 
+
+Documentation : https://docs.omnissa.com/bundle/Horizon8InstallUpgrade/page/AutomatingUpgradesofConnectionServerWithLCMAPIs.html
+
+<!-- Summary End -->
+
+Key aspects of Horizon server lifecycle management include:
+----------------------------------------------------------
+Automation of Installations and Upgrades:
+      The LCM APIs enable automated installations and upgrades of Connection Servers and Enrollment Servers,
+      reducing  manual effort and potential errors. 
+
+REST API Endpoints:
+     The API utilizes RESTful endpoints for managing installations and upgrades, allowing for programmatic control and
+     integration with other systems. 
+
+Installer Status Monitoring:
+     An installer status API endpoint is available to monitor the progress of automated upgrades, providing visibility into
+     the process. 
+
+Prerequisites Validation:
+      APIs allow you to validate that the target machines meets the appropriate requirements. Which includes – System ,
+      Active Directory and vCenter prerequisite.
+
+
+We can use Ansible to automate the lifecycle management of  Horizon 8 deployments using LCM API’s.
+The standard prerequisites apply when using LCM APIs with the Ansible.
+
+Folder Structure:
+----------------
+Horizon_Server_Lifecycle_Managemnt --|
+                                     |--- inventory 			
+					                           |--- playbooks (Install and Upgrade playbooks)
+                                     |--- vars  (Parameters required for playbook execution)
+                                     |--- roles (role to invoke LCM API endpoints.)
+                                     |--- ansible.cfg (config file)                                                                
+
+Note: You can define the necessary parameters for each role in the corresponding "roles/<role name>/defaults/main.yml" file. Alternatively, you have the option to override these parameters at the playbook level by including them in the vars/api_vars.yml file.
+
+Command to execute upgrade flow:
+-------------------------------
+Change directory to playbooks and execute - ansible-playbook Horizon_Server_Upgrade.yml
+
+Command to execute Install flow:
+-------------------------------
+Change directory to playbooks and execute - ansible-playbook Horizon_Server_Install.yml
+                                                                   

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/README.md
@@ -37,12 +37,8 @@ The standard prerequisites apply when using LCM APIs with the Ansible.
 
 Folder Structure:
 ----------------
-Horizon_Server_Lifecycle_Managemnt --|
-                                     |--- inventory 			
-					                           |--- playbooks (Install and Upgrade playbooks)
-                                     |--- vars  (Parameters required for playbook execution)
-                                     |--- roles (role to invoke LCM API endpoints.)
-                                     |--- ansible.cfg (config file)                                                                
+<img width="1006" height="252" alt="image" src="https://github.com/user-attachments/assets/24a5b691-2813-42c4-a13c-c00f89db864f" />
+                                                    
 
 Note: You can define the necessary parameters for each role in the corresponding "roles/<role name>/defaults/main.yml" file. Alternatively, you have the option to override these parameters at the playbook level by including them in the vars/api_vars.yml file.
 

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/ansible.cfg
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = roles

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/playbooks/Horizon_Server_Install.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/playbooks/Horizon_Server_Install.yml
@@ -1,0 +1,153 @@
+- name: Authenticate and invoke role APIs
+  hosts: localhost
+  gather_facts: no
+  connection: local
+  vars_files:
+    - ../vars/secure_vars.yml
+    - ../vars/api_vars.yml
+
+  tasks:
+    - name: Authenticate and get token
+      include_role:
+        name: ../roles/horizon_server_api_auth
+
+    - name: Print token in playbook before calling roles API
+      debug:
+        msg: "Token in playbook is: {{ api_auth_token }}"
+
+    - name: Call role list API
+      include_role:
+        name: ../roles/config_roles
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: role_list_output
+
+    - name: Call role create API
+      include_role:
+        name: ../roles/config_roles
+        tasks_from: create
+      vars:
+        token: "{{ api_auth_token }}"
+        roles_list: "{{ role_list_output }}"
+
+    - name: Call permissions list API
+      include_role:
+        name: ../roles/permissions
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: permissions_list_output
+
+    - name: Call permission assign API
+      include_role:
+        name: ../roles/permissions
+        tasks_from: assign
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "{{ created_role_id }}"
+      register: "{{ permissions_list_output }}"
+
+    - name: Call package list API
+      include_role:
+        name: ../roles/server_installer_packages
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: package_list_output
+
+    - name: Invoke Package Register API
+      include_role:
+        name: ../roles/server_installer_packages
+        tasks_from: register
+      vars:
+        token: "{{ api_auth_token }}"
+        package_list: "{{ package_list_output }}"
+
+    - name: Authenticate and get token
+      include_role:
+        name: ../roles/horizon_server_api_auth
+
+    - name: Print token in playbook before calling roles API
+      debug:
+        msg: "Token in playbook is: {{ api_auth_token }}"
+
+    - name: Pause for 3 minutes
+      ansible.builtin.pause:
+        minutes: 3
+
+    - name: Call role ldap precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: ldap
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role vCenter precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: vcenter
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role ad precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: ad
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role system precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: system
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server + replica_servers + enrollment_servers}}"
+
+    - name: Invoke Install Connection Server
+      include_role:
+        name: ../roles/install_connection_server
+        tasks_from: cs
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "{{ package_id }}"
+
+    - name: Check connection server install status
+      include_role:
+        name: ../roles/install_status_check
+        tasks_from: poll_status
+      vars:
+        target_servers: "{{ connection_server }}"
+        token: "{{ api_auth_token }}"
+        expected_status: "POST_INSTALLATION_CHECK_SUCCESS"
+
+    - name: Invoke Install replica Server
+      include_role:
+        name: ../roles/install_connection_server
+        tasks_from: rs
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "{{ package_id }}"
+      when: api_response.json.status == "POST_INSTALLATION_CHECK_SUCCESS"
+
+    - name: Invoke Install enrollment Server
+      include_role:
+        name: ../roles/install_connection_server
+        tasks_from: es
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "{{ package_id }}"
+      when: api_response.json.status == "POST_INSTALLATION_CHECK_SUCCESS"
+
+    - name: Check replica and enrollment  server install status
+      include_role:
+        name: ../roles/install_status_check
+        tasks_from: poll_status
+      vars:
+        expected_status: "POST_INSTALLATION_CHECK_SUCCESS"
+        target_servers: "{{ replica_servers + enrollment_servers }}"
+        token: "{{ api_auth_token }}"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/playbooks/Horizon_Server_Upgrade.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/playbooks/Horizon_Server_Upgrade.yml
@@ -1,0 +1,118 @@
+- name: Authenticate and invoke role APIs
+  hosts: localhost
+  gather_facts: no
+  connection: local
+  vars_files:
+    - ../vars/secure_vars.yml
+    - ../vars/api_vars.yml
+
+  tasks:
+    - name: Authenticate and get token
+      include_role:
+        name: ../roles/horizon_server_api_auth
+
+    - name: Print token in playbook before calling roles API
+      debug:
+        msg: "Token in playbook is: {{ api_auth_token }}"
+
+    - name: Call role list API
+      include_role:
+        name: ../roles/config_roles
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: role_list_output
+
+    - name: Call role create API
+      include_role:
+        name: ../roles/config_roles
+        tasks_from: create
+      vars:
+        token: "{{ api_auth_token }}"
+        roles_list: "{{ role_list_output }}"
+
+    - name: Call permissions list API
+      include_role:
+        name: ../roles/permissions
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: permissions_list_output
+
+    - name: Call permission assign API
+      include_role:
+        name: ../roles/permissions
+        tasks_from: assign
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "{{ created_role_id }}"
+      register: "{{ permissions_list_output }}"
+
+    - name: Call package list API
+      include_role:
+        name: ../roles/server_installer_packages
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+      register: package_list_output
+
+    - name: Invoke Package Register API
+      include_role:
+        name: ../roles/server_installer_packages
+        tasks_from: register
+      vars:
+        token: "{{ api_auth_token }}"
+        package_list: "{{ package_list_output }}"
+
+    - name: Pause for 3 minutes
+      ansible.builtin.pause:
+        minutes: 3
+
+    - name: Call role ldap precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: ldap
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role vCenter precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: vcenter
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role ad precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: ad
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server }}"
+
+    - name: Call role system precheck
+      include_role:
+        name: ../roles/precheck
+        tasks_from: system
+      vars:
+        token: "{{ api_auth_token }}"
+        target_servers: "{{ connection_server + replica_servers + enrollment_servers}}"
+
+    - name: Invoke Server upgrade
+      include_role:
+        name: ../roles/upgrade_connection_server
+      vars:
+        target_servers: "{{ connection_server + replica_servers + enrollment_servers}}"
+        token: "{{ api_auth_token }}"
+        role_id: "{{ package_id }}"
+
+    - name: Check server upgrade status
+      include_role:
+        name: ../roles/install_status_check
+        tasks_from: poll_status
+      vars:
+        target_servers: "{{ connection_server + replica_servers + enrollment_servers}}"
+        token: "{{ api_auth_token }}"
+        expected_status: "UPGRADE_SUCCESS"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/README.md
@@ -1,0 +1,65 @@
+Config Roles
+============
+
+This Ansible role manages Horizon Server Role configuration API. It supports listing existing roles and creating new roles via REST API calls.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+
+Role Variables
+--------------
+
+Variables are typically provided via `vars_files` in your playbook. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (see `vars/api_vars.yml`).
+- `token`: Bearer token for API authentication.
+- `create_role`: Dictionary describing the role to create (name, description, privileges).
+
+Example
+=======
+create_role:
+  description: "Horizon Server Lifecycle Management Administrators"
+  name: "LCM Admin"
+  privileges: ["LCM_MANAGEMENT"]
+
+Dependencies
+============
+horizon_server_api_auth: For API authentication and token retrieval.
+
+Example Playbook
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: Authenticate and get token
+      include_role:
+        name: horizon_server_api_auth
+
+    - name: List roles
+      include_role:
+        name: config_roles
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+
+    - name: Create role if not exists
+      include_role:
+        name: config_roles
+        tasks_from: create
+      vars:
+        token: "{{ api_auth_token }}"
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# defaults file for config_roles
+api_endpoints:
+  list_roles: "/config/v1/roles"
+  create_roles: "/config/v1/roles"
+
+create_role:
+ description: "Horizon Server Lifecycle Management Administrators"
+ name: "LCM Admin"
+ privileges: ["LCM_MANAGEMENT"]

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for config_roles

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tasks/create.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tasks/create.yml
@@ -1,0 +1,83 @@
+- name: Debug create role request URL
+  debug:
+    msg:
+      - "Calling: {{ api_base_url }}{{ api_endpoints.create_roles }}"
+      - "With token: {{ token }}"
+
+- debug:
+    msg:
+      - "Type: {{ roles_list_response.json | type_debug }}"
+      - "Sample first role: {{ roles_list_response.json[0] }}"
+
+- set_fact:
+    existing_roles: "{{ roles_list_response.json }}"
+
+- name: Set existing_role if found
+  set_fact:
+    existing_role: "{{ item }}"
+  when: item.name == '{{ create_role.name }}'
+  loop: "{{ roles_list_response.json }}"
+
+- name: Skip creation if role exists
+  debug:
+    msg: "Role '{{ create_role.name }}' already exists with ID {{ existing_role.id }}"
+  when: existing_role is defined
+
+- name: Create roles using API token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.create_roles }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body:
+      description: "{{ create_role.description }}"
+      name: "{{ create_role.name }}"
+      privileges: "{{ create_role.privileges }}"
+    return_content: yes
+    validate_certs: no
+    status_code: 201
+  register: roles_create_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  when: existing_role is not defined
+
+- name: Assert response code is 201
+  assert:
+    that:
+      - roles_create_response.status == 201
+    fail_msg: "Expected status 201, got {{ roles_create_response.status }}"
+    success_msg: "Role successfully created with status 201"
+  when: existing_role is not defined
+
+- name: Set created_role_id from existing role
+  set_fact:
+    created_role_id: "{{ existing_role.id }}"
+  when: existing_role is defined
+
+- name: Set created_role_id from location
+  set_fact:
+    created_role_id: "{{ roles_create_response.location | regex_replace('.*/', '') }}"
+  when:
+    - roles_create_response.location is defined
+    - existing_role is not defined
+
+- name: Fail if role ID could not be found
+  fail:
+    msg: "Could not determine created_role_id"
+  when: created_role_id is not defined
+
+- name: Print role id
+  debug:
+    msg: "role id {{ created_role_id }}" 
+  when: created_role_id is defined
+
+- name: Show full response if creation failed
+  debug:
+    var: roles_create_response
+  when: 
+    - roles_create_response is defined
+    - roles_create_response.status is defined
+    - roles_create_response.status != 201
+    - existing_role is not defined

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tasks/list.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tasks/list.yml
@@ -1,0 +1,30 @@
+- name: Debug list role request URL
+  debug:
+    msg: 
+      - "Calling: {{ api_base_url }}{{ api_endpoints.list_roles }}"
+      - "With token: {{ token }}"
+
+- name: List roles using API token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.list_roles }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    body_format: json
+    validate_certs: no
+  register: roles_list_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+
+- name: Show raw roles_list_response
+  debug:
+    var: roles_list_response.json
+
+- name: Print type and value of roles_list_response.json
+  debug:
+    msg:
+      - "Type: {{ roles_list_response.json | type_debug }}"
+      - "Value: {{ roles_list_response.json }}"
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - config_roles

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/config_roles/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for config_roles

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/README.md
@@ -1,0 +1,52 @@
+horizon_server_api_auth
+=======================
+
+This Ansible role authenticates with the Horizon Server REST API and retrieves a bearer token for use in subsequent API calls.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+
+Role Variables
+--------------
+
+The following variables must be defined (typically in your playbook or a `vars` file):
+
+- `api_base_url`: Base URL for the Horizon Server REST API (e.g., `https://your-horizon-server/api`).
+- `api_endpoints`: Dictionary containing endpoint paths, must include a `login` key (e.g., `/v1/login`).
+- `api_username`: Username for API authentication.
+- `api_password`: Password for API authentication.
+- `api_domain`: Domain for API authentication (if required).
+
+Outputs
+=======
+api_auth_token: The bearer token to use in subsequent API requests.
+
+Example
+=======
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: Authenticate and get token
+      include_role:
+        name: horizon_server_api_auth
+
+    - name: Use token in another role
+      include_role:
+        name: config_roles
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for horizon_server_auth
+api_endpoints:
+  login: "/login"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for horizon_server_auth

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tasks/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tasks/main.yml
@@ -1,0 +1,23 @@
+- name: Login to REST API
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.login }}"
+    method: POST
+    validate_certs: no
+    body_format: json
+    body:
+      username: "{{ api_username }}"
+      password: "{{ api_password }}"
+      domain: "{{ api_domain }}"
+    headers:
+      Content-Type: "application/json"
+    return_content: yes
+  register: login_response
+
+- name: Set auth token as fact
+  set_fact:
+    api_auth_token: "{{ login_response.json.access_token }}"
+
+- name: Debug token inside auth role
+  debug:
+    msg: "Auth token (inside auth role) is: {{ api_auth_token }}"
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - horizon_server_api_auth

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/horizon_server_api_auth/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for horizon_server_auth

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/README.md
@@ -1,0 +1,83 @@
+install_connection_server
+========================
+
+This Ansible role automates the installation of Omnissa Horizon Connection Server components (Standard, Replica, and Enrollment servers) via REST API calls.
+
+Role Structure
+--------------
+
+- `tasks/cs.yml`: Installs Standard Connection Servers.
+- `tasks/rs.yml`: Installs Replica Servers.
+- `tasks/es.yml`: Installs Enrollment Servers.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+- Server installer package uploaded and available
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `install_connection_server`).
+- `token`: Bearer token for API authentication.
+- `package_id`: ID of the uploaded server installer package.
+- `install_parameters`: Dictionary containing installation parameters (see below).
+- `connection_server`: List of FQDNs for Standard Connection Servers.
+- `replica_servers`: List of FQDNs for Replica Servers.
+- `enrollment_servers`: List of FQDNs for Enrollment Servers.
+
+- `install_parameters`:
+install_parameters:
+  domain: "yourdomain.local"
+  password: "yourpassword"
+  user_name: "administrator"
+  server_msi_install_spec:
+    admin_sid: "S-1-5-21-..."
+    deployment_type: "CONNECTION_SERVER"
+    fips_enabled: false
+    fw_choice: "enable"
+    html_access: true
+    install_directory: "C:\\Program Files\\VMware\\..."
+    server_recovery_pwd: "recoverypassword"
+    server_recovery_pwd_reminder: "reminder"
+    vdm_ipprotocol_usage: "IPv4"
+
+Usage
+=====
+Include the role and specify which server type to install by using the appropriate task file:
+
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml](http://_vscodecontentref_/0)
+    - [api_vars.yml](http://_vscodecontentref_/1)
+  tasks:
+    - name: Install Standard Connection Servers
+      include_role:
+        name: install_connection_server
+        tasks_from: cs
+
+    - name: Install Replica Servers
+      include_role:
+        name: install_connection_server
+        tasks_from: rs
+
+    - name: Install Enrollment Servers
+      include_role:
+        name: install_connection_server
+        tasks_from: es
+
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# defaults file for install_connection_server
+api_endpoints:
+  install_connection_server: "/config/v1/connection-servers/action/install-connection-server"
+
+install_parameters:
+  domain: "domain"
+  password: "password"
+  server_msi_install_spec:
+    admin_sid: "S-1-5-32-544"
+    deployment_type: "GENERAL"
+    fips_enabled: false
+    fw_choice: true
+    html_access: true
+    install_directory: "%ProgramFiles%\\Omnissa\\Horizon\\Server"
+    server_recovery_pwd: "c"
+    server_recovery_pwd_reminder: "c"
+    vdm_ipprotocol_usage: "IPv4"
+  user_name: "administrator"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for install_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/cs.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/cs.yml
@@ -1,0 +1,56 @@
+---
+# tasks file for install_connection_server
+- name: Invoke Install Connection Server
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.install_connection_server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: >-
+      {{
+        {
+          "domain": install_parameters.domain,
+          "password": install_parameters.password,
+          "server_installer_package_id": package_id,
+          "server_msi_install_spec": {
+            "admin_sid": install_parameters.server_msi_install_spec.admin_sid,
+            "deployment_type": install_parameters.server_msi_install_spec.deployment_type,
+            "fips_enabled": install_parameters.server_msi_install_spec.fips_enabled,
+            "fw_choice": install_parameters.server_msi_install_spec.fw_choice,
+            "html_access": install_parameters.server_msi_install_spec.html_access,
+            "install_directory": install_parameters.server_msi_install_spec.install_directory,
+            "server_instance_type": "STANDARD_SERVER",
+            "server_recovery_pwd": install_parameters.server_msi_install_spec.server_recovery_pwd,
+            "server_recovery_pwd_reminder": install_parameters.server_msi_install_spec.server_recovery_pwd_reminder,
+            "vdm_ipprotocol_usage": install_parameters.server_msi_install_spec.vdm_ipprotocol_usage
+          },
+          "target_server_fqdn": item,
+          "user_name": install_parameters.user_name
+        }
+      }}
+    status_code: 204
+    validate_certs: no
+  register: install_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  loop: "{{ connection_server }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Assert response code is 204
+  assert:
+    that:
+      - item.status == 204
+    fail_msg: "Install failed for {{ item.item }}: expected status 204, got {{ item.status }}"
+    success_msg: "Install API call for {{ item.item }} succeeded with status 204"
+  loop: "{{ install_response.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Set fact for failed installations
+  set_fact:
+    failed_connection_server: "{{ failed_replica_servers | default([]) + [item.item] }}"
+  when: item.status != 204
+  loop: "{{ install_response.results }}"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/es.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/es.yml
@@ -1,0 +1,54 @@
+---
+# tasks file for install_connection_server
+- name: Invoke Install Connection Server
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.install_connection_server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: >-
+      {{
+        {
+          "domain": install_parameters.domain,
+          "password": install_parameters.password,
+          "server_installer_package_id": package_id,
+          "server_msi_install_spec": {
+            "fips_enabled": install_parameters.server_msi_install_spec.fips_enabled,
+            "fw_choice": install_parameters.server_msi_install_spec.fw_choice,
+            "install_directory": install_parameters.server_msi_install_spec.install_directory,
+            "server_instance_type": "ENROLLMENT_SERVER",
+            "vdm_ipprotocol_usage": install_parameters.server_msi_install_spec.vdm_ipprotocol_usage
+          },
+          "target_server_fqdn": item,
+          "user_name": install_parameters.user_name
+        }
+      }}
+    status_code: 204
+    validate_certs: no
+  register: install_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  loop: "{{ enrollment_servers }}"
+  loop_control:
+    label: "{{ item }}"
+
+
+- name: Assert each install API response returned status 204
+  assert:
+    that:
+      - item.status == 204
+    fail_msg: "Install failed for {{ item.item }}: expected status 204, got {{ item.status }}"
+    success_msg: "Install API call for {{ item.item }} succeeded with status 204"
+  loop: "{{ install_response.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Set fact for failed installations
+  set_fact:
+    failed_enrollment_servers: "{{ failed_enrollment_servers | default([]) + [item.item] }}"
+  when: item.status != 204
+  loop: "{{ install_response.results }}"
+
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/rs.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tasks/rs.yml
@@ -1,0 +1,55 @@
+---
+# tasks file for install_replica_server
+- name: Invoke Install Replica Server
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.install_connection_server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: >-
+      {{
+        {
+          "domain": install_parameters.domain,
+          "password": install_parameters.password,
+          "server_installer_package_id": package_id,
+          "server_msi_install_spec": {
+            "fips_enabled": install_parameters.server_msi_install_spec.fips_enabled,
+            "fw_choice": install_parameters.server_msi_install_spec.fw_choice,
+            "html_access": install_parameters.server_msi_install_spec.html_access,
+            "install_directory": install_parameters.server_msi_install_spec.install_directory,
+            "server_instance_type": "REPLICA_SERVER",
+            "primary_connection_server_fqdn": connection_server[0],
+            "vdm_ipprotocol_usage": install_parameters.server_msi_install_spec.vdm_ipprotocol_usage
+          },
+          "target_server_fqdn": item,
+          "user_name": install_parameters.user_name
+        }
+      }}
+    status_code: 204
+    validate_certs: no
+  register: install_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  loop: "{{ replica_servers }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Assert each install API response returned status 204
+  assert:
+    that:
+      - item.status == 204
+    fail_msg: "Install failed for {{ item.item }}: expected status 204, got {{ item.status }}"
+    success_msg: "Install API call for {{ item.item }} succeeded with status 204"
+  loop: "{{ install_response.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Set fact for failed installations
+  set_fact:
+    failed_replica_servers: "{{ failed_replica_servers | default([]) + [item.item] }}"
+  when: item.status != 204
+  loop: "{{ install_response.results }}"
+
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - install_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_connection_server/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for install_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/README.md
@@ -1,0 +1,73 @@
+install_status_check
+===================
+
+This Ansible role polls the Horizon Server REST API to check the installation status of one or more servers (Connection, Replica, or Enrollment servers). It supports automatic re-authentication if the API token expires and collects status results for all target servers.
+
+Role Structure
+--------------
+
+- `tasks/poll_status.yml`: Entry point. Initializes polling for all target servers.
+- `tasks/poll_iteration.yml`: Handles polling in iterations, removing completed servers from the pending list.
+- `tasks/poll_single_server.yml`: Polls the API for a single server's status, handles re-authentication, and updates results.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+- List of target server FQDNs to check
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `install_status`).
+- `token`: Bearer token for API authentication.
+- `target_servers`: List of FQDNs for servers whose install status should be checked.
+- `expected_status`: The status string that indicates installation is complete (e.g., `"INSTALLED"`).
+
+Example:
+api_base_url: "https://your-horizon-server/api"
+api_endpoints:
+  install_status: "/v1/servers/install-status"
+token: "{{ api_auth_token }}"
+target_servers:
+  - "server1.domain.local"
+  - "server2.domain.local"
+expected_status: "INSTALLED"
+
+Usage
+======
+Include the role in your playbook and invoke the polling process:
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: Check install status for servers
+      include_role:
+        name: install_status_check
+        tasks_from: poll_status
+
+Outputs
+=======
+install_status_results: Dictionary mapping each server FQDN to its final status (e.g., { "server1.domain.local": "POST_INSTALLATION_CHECK_SUCCESS" }).
+
+Features
+========
+Polls all target servers in parallel, removing completed ones each iteration.
+Handles API token expiration by re-authenticating as needed.
+Waits 60 seconds between polling attempts for each server.
+Collects and displays error messages if present.
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for installer_ststus_check
+api_endpoints:
+  install_status: "/config/v1/connection-servers/action/retrieve-installer-status"
+
+
+max_retries: 300
+retry_delay: 60

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for installer_ststus_check

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_iteration.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_iteration.yml
@@ -1,0 +1,26 @@
+---
+# roles/install_status_check/tasks/poll_iteration.yml
+
+- name: Initialize list for completed servers in this iteration
+  set_fact:
+    servers_to_remove: []
+
+- name: Process each pending server
+  include_tasks: poll_single_server.yml
+  loop: "{{ pending_servers }}"
+  loop_control:
+    loop_var: server
+
+- name: Update pending servers list
+  set_fact:
+    pending_servers: "{{ pending_servers | difference(servers_to_remove) }}"
+
+- name: Display remaining servers
+  debug:
+    msg: "Remaining servers to poll: {{ pending_servers }}"
+
+- name: Continue polling for remaining servers
+  include_tasks: poll_iteration.yml
+  when: pending_servers | length > 0
+
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_single_server.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_single_server.yml
@@ -1,0 +1,77 @@
+---
+- name: Check API status for server {{ server }}
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.install_status }}?fqdn={{ server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    status_code: 200
+    validate_certs: no
+  register: api_response
+  failed_when: false
+
+- name: Debug full api_response (before retry)
+  debug:
+    var: api_response
+
+- name: Re-authenticate if 401 Unauthorized
+  include_role:
+    name: horizon_server_api_auth
+  when: api_response.status == 401
+
+- name: Retry API status for server {{ server }} with new token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.install_status }}?fqdn={{ server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    status_code: 200
+    validate_certs: no
+  register: api_response_retry
+  failed_when: false
+  when: api_response.status == 401
+
+- name: Use retried response if present and not skipped
+  set_fact:
+    api_response: "{{ api_response_retry }}"
+  when:
+    - api_response_retry is defined
+    - api_response_retry is mapping
+    - api_response_retry.skipped is not defined
+
+- name: Debug full api_response (after retry if any)
+  debug:
+    var: api_response
+
+- name: Print status for server {{ server }}
+  debug:
+    msg: >-
+      Server {{ server }} status:
+      {{ api_response.json.status | default('unknown') }}
+      {% if api_response.json.error_message is defined and api_response.json.error_message != "" %}
+      with error: {{ api_response.json.error_message }}
+      {% endif %}
+
+- name: Evaluate if server {{ server }} is in terminal state
+  set_fact:
+    server_complete: >-
+      {{
+        (api_response.json is defined and api_response.json.status is defined and api_response.json.status == expected_status)
+        or
+        (api_response.json is defined and api_response.json.error_message is defined and api_response.json.error_message != "")
+      }}
+
+- name: Mark server {{ server }} for removal if complete
+  set_fact:
+    servers_to_remove: "{{ servers_to_remove + [ server ] }}"
+  when: server_complete
+
+- name: Save API status result for server
+  set_fact:
+    install_status_results: "{{ (install_status_results | default({})) | combine({ server: (api_response.json['status'] if (api_response.json is defined and 'status' in api_response.json) else 'unknown') }) }}"
+
+- name: Pause 60 seconds before processing next server
+  pause:
+    seconds: 60

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_status.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tasks/poll_status.yml
@@ -1,0 +1,12 @@
+---
+# roles/install_status_check/tasks/poll_status.yml
+
+- name: Initialize pending servers list
+  set_fact:
+    pending_servers: "{{ target_servers }}"
+
+- name: Begin polling process
+  include_tasks: poll_iteration.yml
+  when: pending_servers | length > 0
+
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - installer_ststus_check

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/install_status_check/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for installer_status_check

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/README.md
@@ -1,0 +1,76 @@
+permissions
+===========
+
+This Ansible role manages Horizon Server permissions via REST API calls. It supports listing current permissions and assigning new permissions to roles and users/groups.
+
+Role Structure
+--------------
+
+- `tasks/list.yml`: Lists all current permissions.
+- `tasks/assign.yml`: Assigns a permission to a user/group for a specific role, if not already assigned.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `list_permissions` and `assign_permissions`).
+- `token`: Bearer token for API authentication.
+- `role_id`: The ID of the role to assign permissions to.
+- `assign_permissons`: Dictionary describing the permission assignment.
+
+Example 
+`assign_permissons`:
+assign_permissons:
+  ad_user_or_group_id: "S-1-5-21-..."
+  local_access_group_id: "local-group-id"
+  federation_access_group_id: "federation-group-id"  # If CPA enabled
+
+
+Usage
+======
+Include the role and specify which task to run:
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: List permissions
+      include_role:
+        name: permissions
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+
+    - name: Assign permission to role
+      include_role:
+        name: permissions
+        tasks_from: assign
+      vars:
+        token: "{{ api_auth_token }}"
+        role_id: "your-role-id"
+        assign_permissons:
+          ad_user_or_group_id: "S-1-5-21-..."
+          local_access_group_id: "local-group-id"
+
+Outputs
+=======
+Shows the current permissions and assignment results.
+Asserts successful assignment and displays errors if any.
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# defaults file for permissions
+api_endpoints:
+  list_permissions : "/config/v1/permissions"
+  assign_permissions: "/config/v1/permissions" 
+
+assign_permissions:
+  ad_user_or_group_id: "S-1-5-21-3949112806-1985708904-1648417161-500"
+  local_access_group_id: "d6dc0a92-243b-4d17-ad5d-ed11e840e7f4"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for permissions

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tasks/assign.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tasks/assign.yml
@@ -1,0 +1,82 @@
+#task assign permission
+- name: Debug assign permission request role id
+  debug:
+    msg:
+      - "Calling assign permission with role id : {{ role_id }}"
+
+- set_fact:
+    existing_permissions: "{{ permissions_list_response.json }}"
+
+- name: Set existing_role if found
+  set_fact:
+    permission: "{{ item }}"
+  when: item.role_id == '{{ role_id }}'
+  loop: "{{ permissions_list_response.json }}"
+
+- name: Skip assign if permissions exists
+  debug:
+    msg: "Role '{{ role_id}}' already assigned"
+  when: permission is defined
+
+- name: Build base permission entry
+  set_fact:
+    permission_entry:
+      ad_user_or_group_id: "{{ assign_permissions.ad_user_or_group_id }}"
+      local_access_group_id: "{{ assign_permissions.local_access_group_id }}"
+      role_id: "{{ role_id }}"
+  when: permission is not defined
+
+- name: Conditionally add federation_access_group_id to permission_entry
+  set_fact:
+    permission_entry: >-
+      {{
+        permission_entry | combine(
+          {'federation_access_group_id': assign_permissions.federation_access_group_id}
+        )
+      }}
+  when:
+    - assign_permissions.federation_access_group_id is defined
+    - assign_permissions.federation_access_group_id | length > 0
+  
+- name: Build request body as list
+  set_fact:
+    assign_permission_payload: [ "{{ permission_entry }}" ]
+  when: permission is not defined
+
+- name: Assign permission
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.assign_permissions }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: "{{ assign_permission_payload }}"
+    return_content: yes
+    status_code: 200
+    validate_certs: no
+  register: assign_permission_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  when: permission is not defined
+
+- name: Show full assign_permission_response structure
+  debug:
+    var: assign_permission_response
+
+- name: Assert response code is 200
+  assert:
+    that:
+      - assign_permission_response.status == 200
+    fail_msg: "Expected status 200, got {{ assign_permission_response.status }}"
+    success_msg: "Role successfully created with status 200"
+  when: permission is not defined
+
+- name: Show full response if permission assign fails
+  debug:
+    var: assign_permission_response
+  when: 
+    - assign_permission_response is defined
+    - assign_permission_response.status is defined
+    - assign_permission_response.status != 200
+    - permission is not defined

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tasks/list.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tasks/list.yml
@@ -1,0 +1,24 @@
+- name: List permissions using API token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.list_permissions }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    body_format: json
+    validate_certs: no
+  register: permissions_list_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+
+- name: Show raw permissions_list_response
+  debug:
+    var: permissions_list_response.json
+
+- name: Print type and value of permissions_list_response.json
+  debug:
+    msg:
+      - "Type: {{ permissions_list_response.json | type_debug }}"
+      - "Value: {{ permissions_list_response.json }}"
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - permissions

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/permissions/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for permissions

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/README.md
@@ -1,0 +1,81 @@
+precheck
+========
+
+This Ansible role performs pre-installation validation checks for Omnissa Horizon Connection Server deployments. It calls Horizon Server REST API endpoints to verify system, Active Directory, vCenter, and LDAP requirements for all target servers.
+
+Role Structure
+--------------
+
+- `tasks/system.yml`: Validates system requirements on target servers.
+- `tasks/ad.yml`: Validates Active Directory requirements.
+- `tasks/vcenter.yml`: Validates vCenter requirements.
+- `tasks/ldap.yml`: Validates LDAP requirements.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+- List of target server FQDNs to check
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `validate_system_requirements`, `validate_ad_requirements`, `validate_vCenter_requirements`, `validate_ldap_requirements`).
+- `token`: Bearer token for API authentication.
+- `target_servers`: List of FQDNs for servers to check.
+- `precheck`: Dictionary containing required versions and connection details for AD, vCenter, etc.
+
+Example:
+precheck:
+  cs_version: "8.10"
+  ad:
+    fqdn: "ad.domain.local"
+  vc:
+    fqdn: "vcenter.domain.local"
+    version: "7.0"
+
+Usage
+=====
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml](http://_vscodecontentref_/0)
+    - [api_vars.yml](http://_vscodecontentref_/1)
+  tasks:
+    - name: Run system precheck
+      include_role:
+        name: precheck
+        tasks_from: system
+
+    - name: Run Active Directory precheck
+      include_role:
+        name: precheck
+        tasks_from: ad
+
+    - name: Run vCenter precheck
+      include_role:
+        name: precheck
+        tasks_from: vcenter
+
+    - name: Run LDAP precheck
+      include_role:
+        name: precheck
+        tasks_from: ldap
+
+Outputs
+=======
+Fails the play if any server does not pass the required checks.
+Displays a message if all servers pass the checks.
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# defaults file for precheck
+api_endpoints:
+  validate_ldap_requirements : "/config/v1/connection-servers/action/validate-ldap-requirements"
+  validate_ad_requirements : "/config/v1/connection-servers/action/validate-ad-requirements"
+  validate_system_requirements : "/config/v1/connection-servers/action/validate-system-requirements"
+  validate_vCenter_requirements : "/config/v1/connection-servers/action/validate-virtual-center-requirements"
+
+precheck:
+ cs_version: 2506
+ ad:
+   fqdn : "AD_FQDN"
+ vc:
+   fqdn : "vCenter_FQDN"
+   version: vCenter_Version

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for precheck

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/ad.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/ad.yml
@@ -1,0 +1,51 @@
+---
+# tasks file for precheck
+
+- name: Call ad precheck APIs and register results
+  vars:
+    query_params:
+      target_server_fqdn: "{{ item }}"
+      active_directory_fqdn: "{{ precheck.ad.fqdn }}"
+      target_cs_version: "{{ precheck.cs_version }}"
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.validate_ad_requirements }}?{{ query_params | urlencode }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    validate_certs: no
+    status_code : 200
+  loop: "{{ target_servers }}"
+  loop_control:
+    label: "{{ item }}"
+  register: ad_precheck_response_status
+
+- name: Set unauthorized fact if any 401 found in loop results
+  set_fact:
+    api_call_unauthorized: >-
+      {{
+        ad_precheck_response_status.results
+        | selectattr('status', 'eq', 401)
+        | list
+        | length > 0
+      }}
+
+- name: Check Active Directory validation API responses
+  set_fact:
+    failed_servers: >-
+      {{
+        failed_servers | default([]) + 
+        [item.item] if
+        (item.json | selectattr('response_status', 'ne', 'PASS') | list | length) > 0
+        else failed_servers | default([])
+      }}
+  loop: "{{ ad_precheck_response_status.results }}"
+
+- name: Fail if any server has failed checks
+  fail:
+    msg: "Active Directory validation failed for the following servers: {{ failed_servers }}"
+  when: failed_servers | length > 0
+
+- name: Continue only if all checks passed
+  debug:
+    msg: "All target servers passed the Active Directory validation checks."

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/ldap.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/ldap.yml
@@ -1,0 +1,46 @@
+---
+# tasks file for precheck
+- name: Call all precheck APIs and register results
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.validate_ldap_requirements }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    validate_certs: no
+    status_code : 200
+  loop: "{{ target_servers }}"
+  loop_control:
+    label: item 
+  register: ldap_precheck_response_status
+
+
+- name: Set unauthorized fact if any 401 found in loop results
+  set_fact:
+    api_call_unauthorized: >-
+      {{
+        ldap_precheck_response_status.results
+        | selectattr('status', 'eq', 401)
+        | list
+        | length > 0
+      }}
+
+- name: Check API responses for all servers
+  set_fact:
+    failed_servers: >-
+      {{
+        failed_servers | default([]) + 
+        [item.item] if
+        (item.json | selectattr('response_status', 'ne', 'PASS') | list | length) > 0
+        else failed_servers | default([])
+      }}
+  loop: "{{ ldap_precheck_response_status.results }}"
+
+- name: Fail if any server has failed checks
+  fail:
+    msg: "Verification failed for the following servers: {{ failed_servers }}"
+  when: failed_servers | length > 0
+
+- name: Continue only if all checks passed
+  debug:
+    msg: "All target servers passed the checks."

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/system.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/system.yml
@@ -1,0 +1,49 @@
+---
+# tasks file for precheck
+- name: Call system precheck APIs and register results
+  vars:  
+    query_params:
+      target_server_fqdn: "{{ item }}"
+      target_cs_version: "{{ precheck.cs_version }}"
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.validate_system_requirements }}?{{ query_params | urlencode }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    validate_certs: no
+    status_code : 200
+  loop: "{{ target_servers }}"
+  loop_control:
+    label: "{{ item }}"
+  register: system_precheck_response_status
+
+- name: Set unauthorized fact if any 401 found in loop results
+  set_fact:
+    api_call_unauthorized: >-
+      {{
+        system_precheck_response_status.results
+        | selectattr('status', 'eq', 401)
+        | list
+        | length > 0
+      }}
+
+- name: Check System validation API responses for all servers
+  set_fact:
+    failed_servers: >-
+      {{
+        failed_servers | default([]) + 
+        [item.item] if
+        (item.json | selectattr('response_status', 'ne', 'PASS') | list | length) > 0
+        else failed_servers | default([])
+      }}
+  loop: "{{ system_precheck_response_status.results }}"
+
+- name: Fail if any server has failed checks
+  fail:
+    msg: "System pre check verification failed for the following servers: {{ failed_servers }}"
+  when: failed_servers | length > 0
+
+- name: Continue only if all checks passed
+  debug:
+    msg: "All target servers passed the system pre checks."

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/vcenter.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tasks/vcenter.yml
@@ -1,0 +1,51 @@
+---
+# tasks file for precheck
+- name: Call vCenter precheck APIs and register results
+  vars:
+    query_params:
+      target_server_fqdn: "{{ item }}"
+      target_cs_version: "{{ precheck.cs_version }}"
+      vcenter_fqdn: "{{ precheck.vc.fqdn }}"
+      vcenter_version: "{{ precheck.vc.version }}"
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.validate_vCenter_requirements }}?{{ query_params | urlencode }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    validate_certs: no
+    status_code : 200
+  loop: "{{ target_servers }}"
+  loop_control:
+    label: "{{ item }}"
+  register: vcenter_precheck_response_status
+
+- name: Set unauthorized fact if any 401 found in loop results
+  set_fact:
+    api_call_unauthorized: >-
+      {{
+        vcenter_precheck_response_status.results
+        | selectattr('status', 'eq', 401)
+        | list
+        | length > 0
+      }}
+
+- name: Check vcenter validation API responses
+  set_fact:
+    failed_servers: >-
+      {{
+        failed_servers | default([]) + 
+        [item.item] if
+        (item.json | selectattr('response_status', 'ne', 'PASS') | list | length) > 0
+        else failed_servers | default([])
+      }}
+  loop: "{{ vcenter_precheck_response_status.results }}"
+
+- name: Fail if any server has failed checks
+  fail:
+    msg: "vCenter pre check validation failed for the following servers: {{ failed_servers }}"
+  when: failed_servers | length > 0
+
+- name: Continue only if all checks passed
+  debug:
+    msg: "All target servers passed the vCenter pre checks."

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - precheck

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/precheck/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for precheck

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/README.md
@@ -1,0 +1,82 @@
+server_installer_packages
+========================
+
+This Ansible role manages Horizon Server installer packages via REST API calls. It supports listing available packages and registering new server installer packages if not already present.
+
+Role Structure
+--------------
+
+- `tasks/list.yml`: Lists all registered server installer packages.
+- `tasks/register.yml`: Registers a new server installer package if not already registered.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `list_packages` and `register`).
+- `token`: Bearer token for API authentication.
+- `server_installer`: Dictionary describing the installer package to register.
+
+Example :
+server_installer:
+  build_number: "12345"
+  checksum: "abcdef1234567890"
+  display_name: "Horizon Connection Server 8.10"
+  file_size_in_bytes: 123456789
+  filename: "VMware-Horizon-Connection-Server-8.10.exe"
+  version: "8.10"
+  file_url: "https://your-storage/path/VMware-Horizon-Connection-Server-8.10.exe"
+
+
+Usage
+=====
+Include the role and specify which task to run:
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: List server installer packages
+      include_role:
+        name: server_installer_packages
+        tasks_from: list
+      vars:
+        token: "{{ api_auth_token }}"
+
+    - name: Register server installer package if not present
+      include_role:
+        name: server_installer_packages
+        tasks_from: register
+      vars:
+        token: "{{ api_auth_token }}"
+        server_installer:
+          build_number: "12345"
+          checksum: "abcdef1234567890"
+          display_name: "Horizon Connection Server 8.10"
+          file_size_in_bytes: 123456789
+          filename: "VMware-Horizon-Connection-Server-8.10.exe"
+          version: "8.10"
+          file_url: "https://your-storage/path/VMware-Horizon-Connection-Server-8.10.exe"
+
+Outputs
+=======
+package_id: The ID of the registered or matched server installer package.
+Debug output for package registration and listing.
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# defaults file for ServerInstallerPackages
+api_endpoints:
+  register: "/config/v1/server-installer-packages/action/register"
+  list_packages: "/config/v1/server-installer-packages"
+
+server_installer:
+  file_url: "<https:/webserver/Omnissa-Horizon-Connection-Server-x86_64-2506-8.16.0-15763090940.exe>"
+  build_number: "15763090940"
+  checksum: "5386e4e0d95592dce87108b064d1f7a29afa1a8a4b0ed584a8977471ae098750"
+  display_name: "Omnissa Horizon Connection Server"
+  file_size_in_bytes: "403905776"
+  filename: "Omnissa-Horizon-Connection-Server-x86_64-2506-8.16.0-15763090940.exe"
+  version: "8.16.0"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ServerInstallerPackages

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tasks/list.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tasks/list.yml
@@ -1,0 +1,30 @@
+- name: Debug list role request URL
+  debug:
+    msg: 
+      - "Calling: {{ api_base_url }}{{ api_endpoints.list_packages }}"
+      - "With token: {{ token }}"
+
+- name: List roles using API token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.list_packages }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ token }}"
+    return_content: yes
+    body_format: json
+    validate_certs: no
+  register: package_list_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+
+- name: Show raw roles_list_response
+  debug:
+    var: package_list_response.json
+
+- name: Print type and value of package_list_response.json
+  debug:
+    msg:
+      - "Type: {{ package_list_response.json | type_debug }}"
+      - "Value: {{ package_list_response.json }}"
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tasks/register.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tasks/register.yml
@@ -1,0 +1,87 @@
+---
+# tasks file for server_installer_packages
+- name: Debug response type and sample entry
+  debug:
+    msg:
+      - "Type: {{ package_list_response.json | type_debug }}"
+      - "Sample first package: {{ package_list_response.json[0] | default('No package found') }}"
+
+- name: Set existing_package list
+  set_fact:
+    existing_package: "{{ package_list_response.json }}"
+
+- name: Find existing package by build_number
+  set_fact:
+    matching_package: >-
+      {{ existing_package
+         | selectattr('build_number', 'equalto', server_installer.build_number)
+         | list
+         | first | default({}) }}
+
+- name: Set package_id from already registered package
+  set_fact:
+    package_id: "{{ matching_package.id }}"
+  when: "'id' in matching_package"
+
+- name: Debug matching package if found
+  debug:
+    msg: "Server installer package build '{{ server_installer.build_number }}' already registered with package ID {{ matching_package.id }}"
+  when: "'id' in matching_package"
+
+- name: Skip registration if package is already registered
+  debug:
+    msg: "Skipping registration. Package build '{{ server_installer.build_number }}' already registered with ID {{ matching_package.id }}"
+  when: "'id' in matching_package"
+
+- name: Create roles using API token
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.register }}?fileUrl={{ server_installer.file_url | urlencode }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: "{{ {
+      'build_number': server_installer.build_number,
+      'checksum': server_installer.checksum,
+      'display_name': server_installer.display_name,
+      'file_size_in_bytes': server_installer.file_size_in_bytes | int,
+      'filename': server_installer.filename,
+      'version': server_installer.version,
+    } }}"
+    return_content: yes
+    validate_certs: no
+    status_code: 200
+  register: register_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  when: "'id' not in matching_package"
+
+- name: Assert response code is 200
+  assert:
+    that:
+      - register_response.status == 200
+    fail_msg: "Expected status 200, got {{ register_response.status }}"
+    success_msg: "Package registration successful with status 200"
+  when: "'id' not in matching_package"
+
+- name: Set package_id from already registered package
+  set_fact:
+    package_id: "{{ matching_package.id }}"
+  when: "'id' in matching_package"
+
+- name: Set package_id from response
+  set_fact:
+    package_id: "{{ register_response.json.server_installer_package_id }}"
+  when: "'id' not in matching_package"
+
+- name: Show full response if registration failed
+  debug:
+    var: register_response
+  when:
+    - register_response is defined
+    - register_response.status is defined
+    - register_response.status != 200
+    - "'id' not in matching_package"
+
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ServerInstallerPackages

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/server_installer_packages/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ServerInstallerPackages

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/.travis.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "3.8"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/README.md
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/README.md
@@ -1,0 +1,70 @@
+upgrade_connection_server
+========================
+
+This Ansible role automates the upgrade of Omnissa Horizon Connection Servers via REST API calls. It triggers the upgrade process for one or more target servers using a specified installer package.
+
+Role Structure
+--------------
+
+- `tasks/main.yml`: Main task file that performs the upgrade for all specified target servers.
+
+Requirements
+------------
+
+- Ansible 2.9 or higher
+- Horizon Server REST API endpoint accessible
+- API authentication token (see `horizon_server_api_auth` role)
+- Server installer package already registered and available
+
+Role Variables
+--------------
+
+Variables should be defined in your playbook or a `vars` file. Key variables include:
+
+- `api_base_url`: Base URL for the Horizon Server REST API.
+- `api_endpoints`: Dictionary of API endpoint paths (must include `upgrade_connection_server`).
+- `token`: Bearer token for API authentication.
+- `package_id`: ID of the uploaded server installer package to use for the upgrade.
+- `install_parameters`: Dictionary containing upgrade parameters (see below).
+- `target_servers`: List of FQDNs for servers to upgrade.
+
+- `install_parameters`:
+    domain: "yourdomain.local"
+    password: "yourpassword"
+    user_name: "administrator"
+
+Usage
+=====
+Include the role in your playbook and provide the required variables:
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - [secure_vars.yml]
+    - [api_vars.yml]
+  tasks:
+    - name: Upgrade Connection Servers
+      include_role:
+        name: upgrade_connection_server
+      vars:
+        token: "{{ api_auth_token }}"
+        package_id: "your-package-id"
+        install_parameters:
+          domain: "yourdomain.local"
+          password: "yourpassword"
+          user_name: "administrator"
+        target_servers:
+          - "server1.domain.local"
+          - "server2.domain.local"
+
+Outputs
+=======
+Fails the play if any server upgrade does not return status 204.
+failed_server: List of servers that failed to upgrade.
+
+License
+=======
+BSD
+
+Author Information
+==================
+bsg@omnissa.com

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/defaults/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# defaults file for upgrade_connection_server
+api_endpoints:
+  upgrade_connection_server: "/config/v1/connection-servers/action/upgrade-connection-server"
+
+install_parameters:
+  domain: "yourdomain"
+  password: "password"
+  user_name: "username"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/handlers/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for upgrade_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/meta/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tasks/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# tasks file for install_connection_server
+- name: Invoke Install Connection Server
+  uri:
+    url: "{{ api_base_url }}{{ api_endpoints.upgrade_connection_server }}"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ token }}"
+    body_format: json
+    body: >-
+      {{
+        {
+          "domain": install_parameters.domain,
+          "password": install_parameters.password,
+          "server_installer_package_id": package_id,
+          "target_server_fqdn": item,
+          "user_name": install_parameters.user_name
+        }
+      }}
+    status_code: 204
+    validate_certs: no
+  register: install_response
+  environment:
+    CURL_CA_BUNDLE: ""
+    REQUESTS_CA_BUNDLE: ""
+  loop: "{{ target_servers }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Assert response code is 204
+  assert:
+    that:
+      - item.status == 204
+    fail_msg: "upgrade failed for {{ item.item }}: expected status 204, got {{ item.status }}"
+    success_msg: "upgrade API call for {{ item.item }} succeeded with status 204"
+  loop: "{{ install_response.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Set fact for failed upgrades
+  set_fact:
+    failed_servers: "{{ failed_servers | default([]) + [item.item] }}"
+  when: item.status != 204
+  loop: "{{ install_response.results }}"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tests/inventory
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tests/test.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - upgrade_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/vars/main.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/roles/upgrade_connection_server/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for upgrade_connection_server

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/vars/api_vars.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/vars/api_vars.yml
@@ -1,0 +1,73 @@
+api_base_url: "https://<Horizon_Server_Fqdn>/rest"
+
+connection_server:
+  - ConnectionServer.yourdomain.com
+
+replica_servers:
+  - ReplicaServer1.yourdomain.com
+  - ReplicaServer2.yourdomain.com
+
+enrollment_servers:
+  - EnrollmentServer1.yourdomain.com
+
+# You can specify the parameters required for each role under the respective "roles/<role name>/defaults/main.yml" file
+# or you can override the same at the playbook level by adding it at vars/api_vars.yml
+# Example
+#api_endpoints:
+#  login: "/login"
+#  list_roles: "/config/v1/roles"
+#  create_roles: "/config/v1/roles"
+#  register: "/config/v1/server-installer-packages/action/register"
+#  list_permissions : "/config/v1/permissions"
+#  assign_permissions: "/config/v1/permissions"
+#  install_connection_server: "/config/v1/connection-servers/action/install-connection-server"
+#  upgrade_connection_server: "/config/v1/connection-servers/action/upgrade-connection-server"
+#  install_status: "/config/v1/connection-servers/action/retrieve-installer-status"
+#  validate_ldap_requirements : "/config/v1/connection-servers/action/validate-ldap-requirements"
+#  validate_ad_requirements : "/config/v1/connection-servers/action/validate-ad-requirements"
+#  validate_system_requirements : "/config/v1/connection-servers/action/validate-system-requirements"
+#  validate_vCenter_requirements : "/config/v1/connection-servers/action/validate-virtual-center-requirements"
+
+#precheck:
+# cs_version: 2503
+# ad:
+#   fqdn : "Your Domain FQDN"
+#vc:
+#   fqdn : "Your VC FQDN"
+#   version: 8.0.3
+
+#max_retries: 300
+#retry_delay: 60
+
+#create_role:
+# description: "Horizon Server Lifecycle Management Administrators"
+# name: "LCM Admin"
+# privileges: ["LCM_MANAGEMENT"]
+
+#assign_permissons:
+# ad_user_or_group_id: "Add GUID specific to your environment"
+# local_access_group_id: "Add GUID specific to your environment"
+
+#server_installer:
+# file_url: "https://<YourWebserver>/Omnissa-Horizon-Connection-Server-x86_64-2506-8.16.0-15552271139.exe"
+# build_number: "15552271139"
+# checksum: "ee77fe7a7d447d1f3918aeda8252894b5ec2876b1a7c9a68ea99c11e1d803ed4"
+# display_name: "Omnissa Horizon Connection Server"
+# file_size_in_bytes: "405295848"
+# filename: "Omnissa-Horizon-Connection-Server-x86_64-2506-8.16.0-15552271139.exe"
+# version: "8.16.0"
+
+#install_parameters:
+#  domain: "domain"
+#  password: "password"
+#  server_msi_install_spec:
+#    admin_sid: "S-1-5-32-544"
+#    deployment_type: "GENERAL"
+#    fips_enabled: false
+#    fw_choice: true
+#    html_access: true
+#    install_directory: "%ProgramFiles%\\Omnissa\\Horizon\\Server"
+#    server_recovery_pwd: "c"
+#    server_recovery_pwd_reminder: "c"
+#    vdm_ipprotocol_usage: "IPv4"
+#  user_name: "Administrator"

--- a/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/vars/secure_vars.yml
+++ b/Horizon-Samples/Horizon_Server_Lifecycle_Management/Ansible/vars/secure_vars.yml
@@ -1,0 +1,3 @@
+api_username: "administrator"
+api_password: "password"
+api_domain: "domain"


### PR DESCRIPTION
Horizon server lifecycle management refers to the automation and simplification of installing and upgrading Omnissa Horizon Connection Server and Enrollment Server instances using Lifecycle Management (LCM) APIs.  These APIs, introduced in Horizon 8 version 2406, allow administrators to automate these processes and manage the server's lifecycle more efficiently. 

Adding Ansible playbooks and roles for Horizon Server Lifecycle Management API's to automate Horizon Server install and upgrade process. 